### PR TITLE
Pass month - 1 to the Date constructor, which uses 0-11 for month

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -126,7 +126,7 @@ Notification.prototype.onData = function(data) {
       var minutes = parseInt(dateString.substring(11, 13), 10);
       var seconds = parseInt(dateString.substring(13, 15), 10);
 
-      var date = this.date = new Date(year, month, day, hours, minutes, seconds);
+      var date = this.date = new Date(year, month - 1, day, hours, minutes, seconds);
 
       this.emit('date', date);
     }


### PR DESCRIPTION
The date attribute in the existing code a month in the future since new Date() takes a month that's in the range 0-11 rather than 1-12.